### PR TITLE
Build: Change a build file to copy xsldoc files to API doc directory

### DIFF
--- a/res/ant/build.targets.xml
+++ b/res/ant/build.targets.xml
@@ -155,22 +155,31 @@
   <copy todir="${dir.docs.test}/unit">
    <fileset dir="${dir.res.doc}"/>
   </copy>
-  <copy todir="${dir.docs.api}/xsldoc">
-   <fileset dir="${dir.dist}"/>
-  </copy>
-  <antcall target="deploy:xsldoc"/>
+  <antcall target="deploy:xsldoc:built"/>
+  <antcall target="deploy:xsldoc:dep"/>
   <copy todir="${dir.deploy}">
    <fileset dir="${dir.docs}"/>
   </copy>
  </target>
 
- <target name="deploy:xsldoc" unless="is_xsldoc">
+ <target name="deploy:xsldoc:built" if="is_xsldoc">
+  <copy todir="${dir.docs.api}/xsldoc">
+   <fileset dir="${dir.dist}"/>
+  </copy>
+ </target>
+
+ <target name="deploy:xsldoc:dep" unless="is_xsldoc">
   <copy todir="${dir.docs.api}/xsldoc">
    <fileset dir="${dir.xsldoc}/dist"/>
   </copy>
  </target>
 
  <target name="deploy:xsl:imported" unless="is_application">
+  <copy todir="${dir.docs.api}/xsldoc" flatten="true">
+   <fileset dir="${dir.work.xsl}">
+    <include name="*/dist/*.xsl"/>
+   </fileset>
+  </copy>
   <copy todir="${dir.test.unit}" flatten="true">
    <fileset dir="${dir.work.xsl}">
     <include name="*/dist/*.xsl"/>


### PR DESCRIPTION
### Changed

When xsldoc project, the distribution files (`dist/*`) are needed to be copied to API document directory (`docs/api/xsldoc`), otherwise the xsldoc files downloaded are needed.

Also, when library project, the dependencies distribution files downloaded are needed to be copied there.

This PR adds ant targets for these copies to a build file.